### PR TITLE
Feature/rename-moodle-export

### DIFF
--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/export/rubric/MoodleJSONExporter.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/export/rubric/MoodleJSONExporter.kt
@@ -10,7 +10,7 @@ import org.jagrkt.common.testing.SubmissionInfoImpl
 import org.jagrkt.common.usePrintWriterSafe
 import org.slf4j.Logger
 import java.io.File
-import java.util.*
+import java.util.UUID
 
 class MoodleJSONExporter @Inject constructor(
   private val logger: Logger,

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/export/rubric/MoodleJSONExporter.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/export/rubric/MoodleJSONExporter.kt
@@ -10,6 +10,7 @@ import org.jagrkt.common.testing.SubmissionInfoImpl
 import org.jagrkt.common.usePrintWriterSafe
 import org.slf4j.Logger
 import java.io.File
+import java.util.*
 
 class MoodleJSONExporter @Inject constructor(
   private val logger: Logger,
@@ -22,7 +23,7 @@ class MoodleJSONExporter @Inject constructor(
       StringBuilder().writeTable(gradedRubric).toString(),
     )
     val jsonString = Json.encodeToString(json)
-    directory.resolve("$fileName.json").usePrintWriterSafe(logger) {
+    directory.resolve("${UUID.randomUUID()}.json").usePrintWriterSafe(logger) {
       println(jsonString)
       flush()
     }


### PR DESCRIPTION
The json files in the moodle-export used to have filenames controlled by student submission names. This caused problems when trying to upload to moodle.
Now we use UUIDs as filenames instead.