### PR TITLE
TestCycleResolver

### DIFF
--- a/jagrkt-api/src/main/java/org/jagrkt/api/testing/extension/TestCycleResolver.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/testing/extension/TestCycleResolver.java
@@ -30,9 +30,6 @@ public final class TestCycleResolver implements ParameterResolver {
 
   @Override
   public final boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
-    if (Provider.parameterResolver == null) {
-      return false;
-    }
     return Provider.parameterResolver.supportsParameter(parameterContext, extensionContext);
   }
 

--- a/jagrkt-api/src/main/java/org/jagrkt/api/testing/extension/TestCycleResolver.java
+++ b/jagrkt-api/src/main/java/org/jagrkt/api/testing/extension/TestCycleResolver.java
@@ -1,0 +1,52 @@
+/*
+ *   JagrKt - JagrKt.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jagrkt.api.testing.extension;
+
+import com.google.inject.Inject;
+import org.jetbrains.annotations.ApiStatus;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+public final class TestCycleResolver implements ParameterResolver {
+
+  @Override
+  public final boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+    if (Provider.parameterResolver == null) {
+      return false;
+    }
+    return Provider.parameterResolver.supportsParameter(parameterContext, extensionContext);
+  }
+
+  @Override
+  public final Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+    return Provider.parameterResolver.resolveParameter(parameterContext, extensionContext);
+  }
+
+  @ApiStatus.Internal
+  public static final class Provider {
+    @Inject
+    private static Internal parameterResolver;
+  }
+
+  @ApiStatus.Internal
+  public interface Internal extends ParameterResolver {}
+}

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/CommonModule.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/CommonModule.kt
@@ -21,9 +21,11 @@ package org.jagrkt.common
 
 import com.google.inject.AbstractModule
 import org.jagrkt.api.rubric.*
+import org.jagrkt.api.testing.extension.*
 import org.jagrkt.common.executor.*
 import org.jagrkt.common.rubric.*
 import org.jagrkt.common.rubric.grader.*
+import org.jagrkt.common.testing.*
 
 /**
  * Shared bindings between main and testing guice modules
@@ -35,6 +37,7 @@ abstract class CommonModule : AbstractModule() {
     bind(Grader.Factory::class.java).to(GraderFactoryImpl::class.java)
     bind(GradeResult.Factory::class.java).to(GradeResultFactoryImpl::class.java)
     bind(JUnitTestRef.Factory::class.java).to(JUnitTestRefFactoryImpl::class.java)
+    bind(TestCycleResolver.Internal::class.java).to(TestCycleParameterResolver::class.java)
     bind(Rubric.Factory::class.java).to(RubricFactoryImpl::class.java)
 
     requestStaticInjection(
@@ -43,6 +46,7 @@ abstract class CommonModule : AbstractModule() {
       Grader.FactoryProvider::class.java,
       GradeResult.FactoryProvider::class.java,
       JUnitTestRef.FactoryProvider::class.java,
+      TestCycleResolver.Provider::class.java,
       Rubric.FactoryProvider::class.java,
       TimeoutHandler::class.java,
     )

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/JavaRuntimeTester.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/JavaRuntimeTester.kt
@@ -34,6 +34,7 @@ import org.slf4j.Logger
 
 class JavaRuntimeTester @Inject constructor(
   private val logger: Logger,
+  private val testCycleParameterResolver: TestCycleParameterResolver,
 ) : RuntimeTester {
   override fun createTestCycle(testJar: TestJar, submission: Submission): TestCycle? {
     if (submission !is JavaSubmission) return null
@@ -49,6 +50,7 @@ class JavaRuntimeTester @Inject constructor(
   }
 
   private fun List<ClassSelector>.runJUnit(testCycle: TestCycle): JUnitResultImpl? {
+    testCycleParameterResolver.value = testCycle
     val info = testCycle.submission.info
     logger.info("Running JUnit @ $info :: [${joinToString { it.className }}]")
     val launcher = LauncherFactory.create()

--- a/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/ThreadedGlobalParameterResolver.kt
+++ b/jagrkt-common/src/main/kotlin/org/jagrkt/common/testing/ThreadedGlobalParameterResolver.kt
@@ -1,0 +1,43 @@
+/*
+ *   JagrKt - JagrKt.org
+ *   Copyright (C) 2021 Alexander Staeding
+ *   Copyright (C) 2021 Contributors
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.jagrkt.common.testing
+
+import com.google.inject.Singleton
+import org.jagrkt.api.testing.TestCycle
+import org.jagrkt.api.testing.extension.TestCycleResolver
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.ParameterContext
+import kotlin.reflect.KClass
+
+sealed class ThreadedGlobalParameterResolver<T : Any>(private val type: KClass<T>) : TestCycleResolver.Internal {
+
+  private val valueStorage: InheritableThreadLocal<T> = InheritableThreadLocal()
+  var value: T
+    get() = valueStorage.get()
+    set(value) = valueStorage.set(value)
+
+  override fun supportsParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Boolean =
+    parameterContext.parameter.type == type.java
+
+  override fun resolveParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): T = value
+}
+
+@Singleton
+class TestCycleParameterResolver : ThreadedGlobalParameterResolver<TestCycle>(TestCycle::class)


### PR DESCRIPTION
Adds a `TestCycleResolver` which may be used to resolve a `TestCycle` instance in JUnit tests as follows:

```java
  @Test
  @ExtendWith(TestCycleResolver.class)
  public void testWithTestCycle(TestCycle testCycle) {
  ```